### PR TITLE
feat: Add AI debate feature and fix favicon

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -36,9 +36,10 @@ class Message(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     debate_id = Column(Integer, ForeignKey("debates.id"), nullable=False)
-    sender_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    sender_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     content = Column(Text, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow)
+    sender_type = Column(String, default='user')
 
     debate = relationship("Debate", back_populates="messages")
     sender = relationship("User", back_populates="messages")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -45,16 +45,18 @@ class DebateOut(BaseModel):
 # ------------------ MESSAGE SCHEMAS ------------------ #
 class MessageCreate(BaseModel):
     debate_id: int
-    sender_id: int
+    sender_id: Optional[int] = None
     content: str
+    sender_type: str = 'user'
 
 
 class MessageOut(BaseModel):
     id: int
     content: str
-    sender_id: int
+    sender_id: Optional[int] = None
     debate_id: int
     timestamp: datetime
+    sender_type: str
 
     class Config:
         from_attributes = True

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -11,8 +10,6 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
This commit introduces the initial implementation of the AI debate feature and fixes the favicon.

Backend:
- Created a new endpoint `/debate/{debate_id}/ai-message` to handle AI-powered debates.
- Integrated the Groq API for generating AI responses using the Llama3 model.
- Implemented Socket.IO to enable real-time communication between the frontend and backend during debates.
- Updated the database schema to support AI messages by making the `sender_id` optional and adding a `sender_type` field.

Frontend:
- Connected the `Debate.tsx` component to the new backend endpoint.
- Replaced the hardcoded AI responses with live data from the backend.
- Implemented a Socket.IO client to receive real-time updates during debates.
- Removed the `lovable-tagger` plugin from the Vite configuration to fix the favicon.

Known Issues:
- I was unable to run database migrations due to persistent issues with the Python virtual environment. The backend server also could not be started, which blocked testing of the new features. I attempted to resolve this by trying various commands to activate the virtual environment and install dependencies, but was unsuccessful.