### PR TITLE
feat: Implement dynamic dashboard, leaderboard, and AI bot debating

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ fastapi_app.include_router(auth_routes.router)
 fastapi_app.include_router(debate.router)
 fastapi_app.include_router(leaderboard_routes.router)
 fastapi_app.include_router(dashboard_routes.router)
+fastapi_app.include_router(matchmaking.router)
 
 # Combine Socket.IO and FastAPI into a single ASGI app
 app = socketio.ASGIApp(sio, other_asgi_app=fastapi_app)

--- a/backend/app/matchmaking.py
+++ b/backend/app/matchmaking.py
@@ -1,8 +1,19 @@
 from .socketio_instance import sio
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from . import database, models, schemas
+
+router = APIRouter()
 
 # In-memory store for online users
 # In a production app, you'd use Redis or a similar store
 online_users = {}
+
+@router.post("/match")
+def match(user_id: int, db: Session = Depends(database.get_db)):
+    # This is a placeholder for the old match endpoint.
+    # The new matchmaking logic is handled by websockets.
+    return {"message": "This endpoint is deprecated. Please use websockets."}
 
 @sio.event
 async def connect(sid, environ):

--- a/backend/app/routers/auth_routes.py
+++ b/backend/app/routers/auth_routes.py
@@ -42,24 +42,3 @@ def read_users_me(current_user: models.User = Depends(auth.get_current_user)):
     return current_user
 
 
-@router.post("/match")
-def match(user_id: int, db: Session = Depends(database.get_db)):
-    opponent_id = matchmaking.add_to_queue(user_id)
-    return {"opponent_id": opponent_id}
-
-
-@router.post("/debate")
-def start_debate(
-    debate_data: schemas.DebateCreate,
-    user_id: int,
-    db: Session = Depends(database.get_db)
-):
-    saved = debate.create_debate(db, user_id, debate_data)
-
-    prompt = f"Debate on '{debate_data.topic}' with stance '{debate_data.stance}'"
-    ai_response = ai.get_ai_response(prompt)
-
-    return {
-        "ai_response": ai_response,
-        "debate": saved
-    }


### PR DESCRIPTION
This commit introduces a dynamic dashboard and leaderboard, and enhances the AI bot debating feature.

- **Dynamic Dashboard:**
  - Added new routes to fetch your debate history and statistics from the database.
  - The dashboard now displays dynamic data.

- **Dynamic Leaderboard:**
  - Added a new route to fetch the leaderboard data from the database.
  - The leaderboard page now displays dynamic data.

- **AI Bot Debating:**
  - The matchmaking logic now creates an AI bot when no online users are available.
  - The debate with the AI bot is now evaluated and your ELO is adjusted accordingly.

- **Bug Fixes & Configuration:**
  - Fixed circular dependencies in the backend.
  - Added missing schemas.