### PR TITLE
fix: Resolve frontend and backend errors

### DIFF
--- a/frontend/src/pages/Debate.tsx
+++ b/frontend/src/pages/Debate.tsx
@@ -101,7 +101,7 @@ const Debate = () => {
       clearInterval(timer);
       socket.disconnect();
     };
-  }, [debateId]);
+  }, []);
 
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);


### PR DESCRIPTION
This commit fixes several errors in the frontend and backend.

- **Frontend:**
  - The initial messages are now only fetched once to prevent overwhelming the backend with requests.
- **Backend:**
  - The `debateId` is now correctly handled as an integer in the `end_debate` event.