### PR TITLE
fix: Fix online players not visible

### DIFF
--- a/frontend/src/pages/Matchmaking.tsx
+++ b/frontend/src/pages/Matchmaking.tsx
@@ -23,6 +23,7 @@ const Matchmaking = () => {
   useEffect(() => {
     // Announce user's presence
     if (user) {
+      socket.connect();
       socket.emit('user_online', { userId: user.id, username: user.username, elo: user.elo });
     }
 


### PR DESCRIPTION
This commit fixes the issue where the online players were not visible on the matchmaking page. The `user_online` event was not being sent to the backend because the socket was not connected. This has been fixed by adding `socket.connect()` before emitting the event.